### PR TITLE
Add Dockerfiles and Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Base image
+FROM oven/bun:1 AS base
+WORKDIR /app
+
+# Install dependencies
+FROM base AS deps
+COPY package.json bun.lockb* ./
+RUN bun install --frozen-lockfile
+
+# Build stage
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Build Next.js
+RUN bun run build
+
+# Production stage
+FROM base AS runner
+ENV NODE_ENV=production
+
+# Create non-root user
+RUN groupadd -r -g 1001 nodejs && useradd -r -u 1001 -g nodejs nextjs
+
+# Copy required files
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["bun", "server.js"]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,36 @@ To run Convelyze locally, follow these steps:
 4. **Open the Application**:
    Once the server is running, open your browser and go to `http://localhost:3000` to see the application.
 
+## Run with Docker
+
+To run Convelyze with Docker, follow these steps:
+
+1. **Clone the Repository**:
+   ```bash
+   git clone https://github.com/meetpateltech/convelyze.git
+   cd convelyze
+   ```
+
+2. **Build and Start with Docker Compose**:
+   ```bash
+   docker-compose up -d
+   ```
+
+3. **Open the Application**:
+   Once the container is running, open your browser and go to `http://localhost:3000` to see the application.
+
+4. **Stop the Application**:
+   To stop the application, run:
+   ```bash
+   docker-compose down
+   ```
+
+### Docker Commands
+
+- **Build the image**: `docker-compose build`
+- **View logs**: `docker-compose logs -f`
+- **Restart**: `docker-compose restart`
+
 ## Contributing
 
 Convelyze is open source, and contributions are welcome! If you would like to contribute, follow these steps:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To run Convelyze with Docker, follow these steps:
 
 2. **Build and Start with Docker Compose**:
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 3. **Open the Application**:
@@ -121,14 +121,14 @@ To run Convelyze with Docker, follow these steps:
 4. **Stop the Application**:
    To stop the application, run:
    ```bash
-   docker-compose down
+   docker compose down
    ```
 
 ### Docker Commands
 
-- **Build the image**: `docker-compose build`
-- **View logs**: `docker-compose logs -f`
-- **Restart**: `docker-compose restart`
+- **Build the image**: `docker compose build`
+- **View logs**: `docker compose logs -f`
+- **Restart**: `docker compose restart`
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  convelyze:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: convelyze
+    ports:
+      - "${CONVELYZE_PORT:-3000}:3000" # Expose port 3000 on the container to port 3000 on the host (default)
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@ import { setupDevPlatform } from '@cloudflare/next-on-pages/next-dev';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   webpack: (config, { isServer }) => {
     // Enable asynchronous WebAssembly
     config.experiments = {


### PR DESCRIPTION
- Added Docker/convelyze/Dockerfile: multi-stage Bun-based build that installs dependencies, builds the Next.js app, and prepares a small production image using the standalone output.
- Updated next.config.mjs: set output: 'standalone' to enable Next.js standalone builds.

P.S.
thank you for open-sourcing Convelyze. it's a very useful project!
I noticed that the repository currently does not include a LICENSE file. 
If you have a preferred license in mind,  I’d be happy to follow it or submit a separate PR.
Thanks again for your work!